### PR TITLE
update: AI가 이전 대화 기록을 기억하도록 프롬프트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import ChatInput from './components/ChatInput';
 import MindMap from './components/MindMap';
 import TopBar from './components/TopBar';
 import { useAuthStore } from './stores/authStore';
-import { sendChatMessage, ChatApiError } from './services/chatApi';
+import { sendChatMessage, ChatApiError, ChatMessage } from './services/chatApi';
 import styles from './App.module.css';
 
 // 더미 출처 데이터
@@ -13,6 +13,14 @@ const sources = [
   { id: 2, title: '기술 스택 문서', url: 'https://notion.so/tech-stack' },
   { id: 3, title: 'API 설계 문서', url: 'https://notion.so/api-design' },
 ];
+
+// Message 타입을 ChatMessage 타입으로 변환하는 함수
+const convertToChatMessages = (messages: Message[]): ChatMessage[] => {
+  return messages.map(msg => ({
+    type: msg.sender === 'user' ? 'user' : 'ai',
+    content: msg.text
+  }));
+};
 
 const App: React.FC = () => {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -59,13 +67,16 @@ const App: React.FC = () => {
   }, [setUser]);
 
   const handleSend = async (text: string) => {
+    // 현재 채팅창의 모든 대화 기록을 ChatMessage 형식으로 변환
+    const chatHistory = convertToChatMessages(messages);
+    
     // 사용자 메시지 즉시 추가
     setMessages(prev => [...prev, { sender: 'user', text }]);
     setIsLoading(true);
 
     try {
-      // AI API 호출
-      const aiResponse = await sendChatMessage(text, user?.id || 'anonymous');
+      // AI API 호출 (현재 채팅창의 모든 대화 기록 포함)
+      const aiResponse = await sendChatMessage(text, user?.id || 'anonymous', chatHistory);
       
       // AI 응답 추가
       setMessages(prev => [...prev, { sender: 'ai', text: aiResponse }]);


### PR DESCRIPTION
### 시스템 프롬프트 잘못 추가하면 발생하는 일

이전 대화 기록은 잊어야한다는 규칙을 추가하니까 계속 잊어버렸다고 답변함

<img width="457" height="197" alt="스크린샷 2025-08-17 오후 10 51 28" src="https://github.com/user-attachments/assets/6726becc-124f-486a-b7ae-169110b44bc3" />

그래서 해당 규칙은 삭제했음

```
1. 이전까지의 대화 기록은 당신이 무슨 맥락으로 이야기중인지 참고하는 용도입니다.
2. 대화 내용은 [이전까지의 대화 기록], [현재 사용자의 질문] 파트로 나뉩니다. 당신은 현재 사용자의 질문에 대한 내용을 작성해야합니다.
```

<img width="481" height="551" alt="스크린샷 2025-08-17 오후 10 53 28" src="https://github.com/user-attachments/assets/d1eb1d44-551a-43bb-96aa-53df7d3c9baf" />
